### PR TITLE
Enable BLF for Evolution contacts

### DIFF
--- a/docs/modules/ROOT/examples/sample.conf
+++ b/docs/modules/ROOT/examples/sample.conf
@@ -640,6 +640,11 @@
 ## (optional, default: true)
 # enabled=true
 
+## Comma-separated list of Evolution phone fields that should expose SIP buddy state.
+## Supported values: company, mobile, home
+## (optional, default: none)
+# sipStatusSubscriptableFields="company,mobile"
+
 
 ## An Akonadi contacts block defines an Akonadi source for the address book.
 # [akonadi-contacts]

--- a/resources/templates/sample.conf
+++ b/resources/templates/sample.conf
@@ -515,6 +515,18 @@ port=5061
 ## (optional)
 #sipStatusSubscriptableAttributes="telephoneNumber"
 
+## An Evolution Data Server contacts block defines an Evolution source for the address book.
+# [eds-contacts]
+
+## If left unconfigured, the plugin will simply be enabled by default.
+## (optional, default: true)
+# enabled=true
+
+## Comma-separated list of Evolution phone fields that should expose SIP buddy state.
+## Supported values: company, mobile, home
+## (optional, default: none)
+# sipStatusSubscriptableFields="company,mobile"
+
 ## Realm as it might be required for SASL LDAP bind
 ## default: ""
 ## (optional)

--- a/src/contacts/eds/EDSAddressBookFeeder.h
+++ b/src/contacts/eds/EDSAddressBookFeeder.h
@@ -5,6 +5,8 @@
 #include <glib.h>
 
 #include <QObject>
+#include <QSet>
+#include "Contact.h"
 #include "IAddressBookFeeder.h"
 
 class AddressBookManager;
@@ -21,8 +23,9 @@ public:
 
 private:
     QString getField(EContact *contact, EContactField id);
-    QString getFieldMerge(EContact *contact, EContactField pId, EContactField sId);
     void addAvatar(QString id, EContact *contact, QDateTime changed);
+    QList<Contact::PhoneNumber> collectPhoneNumbers(EContact *contact) const;
+    bool isSipStatusSubscriptable(EContactField field) const;
 
     bool init();
     void feedAddressBook();
@@ -46,4 +49,5 @@ private:
     gchar *m_searchExpr = nullptr;
     QList<EBookClient *> m_clients;
     QList<EBookClientView *> m_clientViews;
+    QSet<EContactField> m_sipStatusSubscriptableFields;
 };


### PR DESCRIPTION
## Summary
- allow the Evolution Data Server feeder to read a new `sipStatusSubscriptableFields` option and flag the corresponding phone numbers for SIP buddy state subscriptions
- reuse the helper when building phone lists so Evolution contacts can surface BLF indicators on the configured fields
- document the new option in the sample configuration files

## Testing
- cmake --workflow --preset default *(fails: bundled CMake is too old to read preset version 10)*
- cmake -S . -B build -G Ninja -DBUILD_DEPENDENCIES=ON *(fails: missing Qt6 development files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbd01035c8321ae01996c52740826